### PR TITLE
avoid noImplicitAny

### DIFF
--- a/dist/types/event-callback.d.ts
+++ b/dist/types/event-callback.d.ts
@@ -1747,7 +1747,7 @@ export declare function event_subsession_invite_to_back_to_main_session(payload:
    * Inviter name
    */
   inviterName: string;
-});
+}): void;
 /**
  * Occurs when there is a change in the status of users in the subsession.
  * @param payload
@@ -1794,7 +1794,7 @@ export declare function event_subsession_user_update(payload: {
    * Whether the user is talking.
    */
   isTalking?: boolean;
-});
+}): void;
 /**
  * Occurs when the broadcasted voice's status changes.
  * @param payload
@@ -1805,7 +1805,7 @@ export declare function event_subsession_broadcast_voice(payload: {
    * Whether the user is receiving the broadcasted voice.
    */
   status: boolean;
-});
+}): void;
 
 /**
  * Occurs when the CRC(Cloud Room Connector) device call state changes.


### PR DESCRIPTION
I have configured the TypeScript compiler with strict options. However, I am encountering an issue where I'm unable to utilize `zoom/videosdk` version 1.10.0 due to these settings. 

Therefore, I suggest that we explicitly set the return type for our functions to resolve this issue.

```log
Error: node_modules/@zoom/videosdk/dist/types/event-callback.d.ts:1737:25 - error TS7010: 'event_subsession_invite_to_back_to_main_session', which lacks return-type annotation, implicitly has an 'any' return type.

1737 export declare function event_subsession_invite_to_back_to_main_session(payload: {
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Error: node_modules/@zoom/videosdk/dist/types/event-callback.d.ts:1756:25 - error TS7010: 'event_subsession_user_update', which lacks return-type annotation, implicitly has an 'any' return type.

1756 export declare function event_subsession_user_update(payload: {
~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Error: node_modules/@zoom/videosdk/dist/types/event-callback.d.ts:1803:25 - error TS7010: 'event_subsession_broadcast_voice', which lacks return-type annotation, implicitly has an 'any' return type.

1803 export declare function event_subsession_broadcast_voice(payload: {
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```